### PR TITLE
Setup Supervisor

### DIFF
--- a/apps/info_sys/lib/info_sys/application.ex
+++ b/apps/info_sys/lib/info_sys/application.ex
@@ -8,8 +8,6 @@ defmodule InfoSys.Application do
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [
-      # Starts a worker by calling: InfoSys.Worker.start_link(arg)
-      # {InfoSys.Worker, arg}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/apps/info_sys/lib/info_sys/counter.ex
+++ b/apps/info_sys/lib/info_sys/counter.ex
@@ -26,6 +26,13 @@ defmodule InfoSys.Counter do
   end
 
   @doc """
+    Initialization, taking initial value as arg
+  """
+  def init(initial_val) do
+    {:ok, initial_val}
+  end
+
+  @doc """
     Handle cast for :inc or :dec to increment or decrement accordingly
   """
   def handle_cast(:inc, val) do


### PR DESCRIPTION
Supervisor was setup for demo purposes with a restart strategy of
one_for_all. Removed strategy and added `init` to the GenServer that
was previously missed