### PR TITLE
Build Backend and Implement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ erl_crash.dump
 rumbl_umbrella.iml
 /apps/rumbl/rumbl.iml
 /apps/rumbl_web/rumbl_web.iml
+
+# Do not commit file with ENV variables
+/.env

--- a/apps/info_sys/lib/info_sys.ex
+++ b/apps/info_sys/lib/info_sys.ex
@@ -13,16 +13,40 @@ defmodule InfoSys do
     defstruct score: 0, text: nil, backend: nil
   end
 
+  alias InfoSys.Cache
+
   @doc """
-    Main entry point for service. Maps over all backends and calls
-    `async_query` for each one
+    Main entry point for service. First the cache for each backend is read
+    given a query, those values are joined to the fetched results, and new
+    values are written to the cache. Maps over all backends and calls
+    `async_query` for each one. `yield_many` waits on all tasks, taking no more
+    than a given time for execution. So results from any backends that have
+    crashed or are unresponsive get ignored. Those tasks are also killed
+    immediately, with only successful results worked with
+
+    When results are received, they're sorted by score and the top results are
+    returned up to a given limit
   """
   def compute(query, opts \\ []) do
+    timeout = opts[:timeout] || 10_000
     opts = Keyword.put_new(opts, :limit, 10)
     backends = opts[:backends] || @backends
 
-    backends
+    {uncached_backends, cached_results} =
+      fetch_cached_results(backends, query, opts)
+
+    uncached_backends
     |> Enum.map(&async_query(&1, query, opts))
+    |> Task.yield_many(timeout)
+    |> Enum.map(fn {task, res} -> res || Task.shutdown(task, :brutal_kill) end)
+    |> Enum.flat_map(fn
+      {:ok, results} -> results
+      _ -> []
+    end)
+    |> write_results_to_cache(query, opts)
+    |> Kernel.++(cached_results)
+    |> Enum.sort(&(&1.score >= &2.score))
+    |> Enum.take(opts[:limit])
   end
 
   @doc """
@@ -35,5 +59,38 @@ defmodule InfoSys do
   defp async_query(backend, query, opts) do
     Task.Supervisor.async_nolink(InfoSys.TaskSupervisor, backend, :compute,
       [query, opts], shutdown: :brutal_kill)
+  end
+
+  @doc """
+    Take all backends and accumulate the cached results for a given query, as
+    well as the backends that contain no cached information. This returns both
+    the cached result set and the backends that need fresh queries
+  """
+  defp fetch_cached_results(backends, query, opts) do
+    {uncached_backends, results} =
+      Enum.reduce(
+        backends,
+        {[], []},
+        fn backend, {uncached_backends, acc_results} ->
+          case Cache.fetch({backend.name(), query, opts[:limit]}) do
+            {:ok, results} -> {uncached_backends, [results | acc_results]}
+            :error -> {[backend | uncached_backends], acc_results}
+          end
+        end
+      )
+
+    {uncached_backends, List.flatten(results)}
+  end
+
+  @doc """
+    Write uncached results to the cache using the backend, query, and relevant
+    options as the cache key
+  """
+  defp write_results_to_cache(results, query, opts) do
+    Enum.map(results, fn %Result{backend: backend} = result ->
+      :ok = Cache.put({backend.name(), query, opts[:limit]}, result)
+
+      result
+    end)
   end
 end

--- a/apps/info_sys/lib/info_sys/backend.ex
+++ b/apps/info_sys/lib/info_sys/backend.ex
@@ -1,0 +1,10 @@
+defmodule InfoSys.Backend do
+  @doc """
+    Typespecs that name the functions, types of args, and return values. `name`
+    takes no args and returns a string. `compute` takes a String.t query, a
+    Keyword.t list of options, and returns a list of %InfoSys.Result{} structs
+  """
+  @callback name() :: String.t()
+  @callback compute(query :: String.t(), opts :: Keyword.t()) ::
+              [%InfoSys.Result{}]
+end

--- a/apps/info_sys/lib/info_sys/wolfram.ex
+++ b/apps/info_sys/lib/info_sys/wolfram.ex
@@ -1,0 +1,63 @@
+defmodule InfoSys.Wolfram do
+  import SweetXml
+  alias InfoSys.Result
+
+  @doc """
+    Establishes module as an implementation of InfoSys.Backend
+  """
+  @behaviour InfoSys.Backend
+
+  @base "http://api.wolframalpha.com/v2/query"
+
+  @impl true
+  def name, do: "wolfram"
+
+  @doc """
+    Build pipe to take our query, fetch the XML, use the `xpath` function from
+    SweetXml to extract the results, and build the results.
+
+    The `@impl true`
+    notation indicates the function as an implementation of a behaviour
+  """
+  @impl true
+  def compute(query_str, _opts) do
+    query_str
+    |> fetch_xml()
+    |> xpath(~x"/queryresult/pod[contains(@title, 'Result') or
+                                 contains(@title, 'Definitions')]
+                            /subpod/plaintext/text()")
+    |> build_results()
+  end
+
+  @doc """
+    Build a list of result structs, with the form depending on whether or not
+    results are obtained. Matching is done on the first argument in the
+    function head - if it's nil just return an empty list.
+
+    If there is a match, build a list of Result structs with expected results
+    and score, then return to the caller
+  """
+  defp build_results(nil), do: []
+
+  defp build_results(answer) do
+    [%Result{backend: __MODULE__, score: 95, text: to_string(answer)}]
+  end
+
+  @doc """
+    Contact WolframAlpha with the query string using :httpc, part of the
+    Erlang standard library. This is a straight HTTP request and it matches
+    against :ok and the body that's returned to the calling client
+  """
+  defp fetch_xml(query) do
+    {:ok, {_, _, body}} = :httpc.request(String.to_charlist(url(query)))
+
+    body
+  end
+
+  defp url(input) do
+    "#{@base}?" <>
+    URI.encode_query(appid: id(), input: input, format: "plaintext")
+  end
+
+  defp id, do: Application.fetch_env!(:info_sys, :wolfram)[:app_id]
+end

--- a/apps/info_sys/mix.exs
+++ b/apps/info_sys/mix.exs
@@ -26,9 +26,7 @@ defmodule InfoSys.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
-      # {:sibling_app_in_umbrella, in_umbrella: true}
+      {:sweet_xml, "~> 0.6.5"}
     ]
   end
 end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -74,3 +74,11 @@ config :phoenix, :plug_init_mode, :runtime
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
+
+wolfram_app_id =
+  System.get_env("WOLFRAM_APP_ID") ||
+    raise """
+      environment variable WOLFRAM_APP_ID is missing.
+    """
+
+config :info_sys, :wolfram, app_id: wolfram_app_id

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -27,6 +27,14 @@ config :rumbl_web, RumblWeb.Endpoint,
   http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
   secret_key_base: secret_key_base
 
+wolfram_app_id =
+  System.get_env("WOLFRAM_APP_ID") ||
+    raise """
+      environment variable WOLFRAM_APP_ID is missing.
+    """
+
+config :info_sys, :wolfram, app_id: wolfram_app_id
+
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/mix.lock
+++ b/mix.lock
@@ -22,5 +22,6 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.15.1", "23ce3417de70f4c0e9e7419ad85bdabcc6860a6925fe2c6f3b1b5b1e8e47bf2f", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
+  "sweet_xml": {:hex, :sweet_xml, "0.6.6", "fc3e91ec5dd7c787b6195757fbcf0abc670cee1e4172687b45183032221b66b8", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Build a backend with typespecs, then implement the behaviour in a
module for tying into WolframAlpha as a backend. The Wolfram module
sends a query string to WolframAlpha, which responds with XML for
which SweetXml was added as a dependency for handling. A developer
ID was created with WolframAlpha and stored in an unversioned file
for dev, but would be setup as an ENV variable when deployed. The
results are built into a InfoSys.Result struct, which is defined in
the InfoSys module.

Backend calls were built to be accessible by any number of configured
backend services. They are supervised, incorporate timeouts enforced by
tasks, implement caching, sort results on relevance, and return up to
a specified number of results