### PR TITLE
Integrate Information System With Channels

### DIFF
--- a/apps/rumbl/priv/repo/backend_seeds.exs
+++ b/apps/rumbl/priv/repo/backend_seeds.exs
@@ -1,0 +1,1 @@
+{:ok, _} = Rumbl.Accounts.create_user(%{name: "Wolfram", username: "wolfram"})

--- a/apps/rumbl_web/lib/rumbl_web/channels/video_channel.ex
+++ b/apps/rumbl_web/lib/rumbl_web/channels/video_channel.ex
@@ -54,22 +54,53 @@ defmodule RumblWeb.VideoChannel do
 
   @doc """
     Call `annotate_video` and if annotation is successfully added,
-    broadcast to all users, including user that added it. Otherwise, return
-    changeset errors
+    broadcast to all users, including user that added it. Also start an async
+    Task to call `compute_additional_info`, which leverages the information
+    system. Using Task.start is OK because failure doesn't matter and
+    messages arriving to the channel shouldn't be blocked
   """
   def handle_in("new_annotation", params, user, socket) do
     case Multimedia.annotate_video(user, socket.assigns.video_id, params) do
       {:ok, annotation} ->
-        broadcast!(socket, "new_annotation", %{
-          id: annotation.id,
-          user: RumblWeb.UserView.render("user.json", %{user: user}),
-          body: annotation.body,
-          at: annotation.at
-        })
+        broadcast_annotation(socket, user, annotation)
+        Task.start(fn -> compute_additional_info(annotation, socket) end)
         {:reply, :ok, socket}
 
         {:error, changeset} ->
           {:reply, {:error, %{errors: changeset}}, socket}
+    end
+  end
+
+  @doc """
+    Handle broadcasting of a new annotation
+  """
+  defp broadcast_annotation(socket, user, annotation) do
+    broadcast!(socket, "new_annotation", %{
+      id: annotation.id,
+      user: RumblWeb.UserView.render("user.json", %{user: user}),
+      body: annotation.body,
+      at: annotation.at
+    })
+  end
+
+  @doc """
+    Call the information system asking for only one result and with a timeout
+    of ten seconds. Use a comprehension to get the backend user from the
+    Accounts context, get relevant attrs and annotate the video. After
+    annotation, broadcast the annotation to all subscribers of the topic
+  """
+  defp compute_additional_info(annotation, socket) do
+    for result <- InfoSys.compute(annotation.body, limit: 1, timeout: 10_000) do
+      backend_user = Accounts.get_user_by(username: result.backend.name())
+      attrs = %{body: result.text, at: annotation.at}
+
+      case Multimedia.annotate_video(
+        backend_user, annotation.video_id, attrs) do
+
+        {:ok, info_ann} ->
+          broadcast_annotation(socket, backend_user, info_ann)
+          {:error, _changeset} -> :ignore
+      end
     end
   end
 end

--- a/apps/rumbl_web/mix.exs
+++ b/apps/rumbl_web/mix.exs
@@ -46,6 +46,7 @@ defmodule RumblWeb.MixProject do
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
       {:rumbl, in_umbrella: true},
+      {:info_sys, in_umbrella: true},
       {:jason, "~> 1.0"},
       {:plug_cowboy, "~> 2.0"}
     ]


### PR DESCRIPTION
Add the information system as a dependency of RumblWeb, then update
the VideoChannel to leverage InfoSys. When annotating a video the
annotation is immediately broadcast to all users in the topic, but
the information system has ten seconds to take the annotation as a
query and respond with relevant information. If there is a return, it
is posted as an annotation by the backend name. Also added a file for
seeding the User table with backend users