### PR TITLE
Test Cache

### DIFF
--- a/apps/info_sys/test/cache_test.exs
+++ b/apps/info_sys/test/cache_test.exs
@@ -1,0 +1,67 @@
+defmodule InfoSysTest.CacheTest do
+  use ExUnit.Case, async: true
+  alias InfoSys.Cache
+  @moduletag clear_interval: 100
+
+  @doc """
+    Start a monitor, then unlink the process. Remove the link so test process
+    doesn't crash, then kill the process to ensure the monitor receives the
+    proper :DOWN message
+  """
+  defp assert_shutdown(pid) do
+    ref = Process.monitor(pid)
+    Process.unlink(pid)
+    Process.exit(pid, :kill)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+  end
+
+  @doc """
+    Prevent tests from having to sleep long periods while waiting on an
+    expected result.
+  """
+  defp eventually(func) do
+    if func.() do
+      true
+    else
+      Process.sleep(10)
+      eventually(func)
+    end
+  end
+
+  setup %{test: name, clear_interval: clear_interval} do
+    {:ok, pid} = Cache.start_link(name: name, clear_interval: clear_interval)
+    {:ok, name: name, pid: pid}
+  end
+
+  test "key value pairs can be put and fetched from cache", %{name: name} do
+    assert :ok = Cache.put(name, :key1, :value1)
+    assert :ok = Cache.put(name, :key2, :value2)
+
+    assert Cache.fetch(name, :key1) == {:ok, :value1}
+    assert Cache.fetch(name, :key2) == {:ok, :value2}
+  end
+
+  test "unfound entry returns error", %{name: name} do
+    assert Cache.fetch(name, :notexists) == :error
+  end
+
+  test "clears all entries after clear interval", %{name: name} do
+    assert :ok = Cache.put(name, :key1, :value1)
+    assert Cache.fetch(name, :key1) == {:ok, :value1}
+    assert eventually(fn -> Cache.fetch(name, :key1) == :error end)
+  end
+
+  @doc """
+    Raise the clear_interval so it won't interfere with the testing of
+    shutdown. We want to test that the shutdown clears the cache and not the
+    clear_interval
+  """
+  @tag clear_interval: 60_000
+  test "values are cleaned up on exit", %{name: name, pid: pid} do
+    assert :ok = Cache.put(name, :key1, :value1)
+    assert_shutdown(pid)
+    {:ok, _cache} = Cache.start_link(name: name)
+    assert Cache.fetch(name, :key1) == :error
+  end
+end

--- a/apps/info_sys/test/info_sys_test.exs
+++ b/apps/info_sys/test/info_sys_test.exs
@@ -2,7 +2,4 @@ defmodule InfoSysTest do
   use ExUnit.Case
   doctest InfoSys
 
-  test "greets the world" do
-    assert InfoSys.hello() == :world
-  end
 end


### PR DESCRIPTION
Remove default tests generated for InfoSys that fail, and create
tests for InfoSys.Cache. Use a moduletag to set a default value for
use in tests, create two helper methods for testing a Process shutdown
and prevent excessive test sleeping.