### PR TITLE
Test Wolfram Backend

### DIFF
--- a/apps/info_sys/lib/info_sys/wolfram.ex
+++ b/apps/info_sys/lib/info_sys/wolfram.ex
@@ -47,9 +47,13 @@ defmodule InfoSys.Wolfram do
     Contact WolframAlpha with the query string using :httpc, part of the
     Erlang standard library. This is a straight HTTP request and it matches
     against :ok and the body that's returned to the calling client
+
+    Look up an :http_client module from the mix config and default it to the
+    :httpc module, which is available via @http module attribute
   """
+  @http Application.get_env(:info_sys, :wolfram)[:http_client] || :httpc
   defp fetch_xml(query) do
-    {:ok, {_, _, body}} = :httpc.request(String.to_charlist(url(query)))
+    {:ok, {_, _, body}} = @http.request(String.to_charlist(url(query)))
 
     body
   end

--- a/apps/info_sys/test/backends/http_client.exs
+++ b/apps/info_sys/test/backends/http_client.exs
@@ -1,0 +1,10 @@
+defmodule InfoSys.Test.HTTPClient do
+  @wolfram_xml File.read!("test/fixtures/wolfram.xml")
+  def request(url) do
+    url = to_string(url)
+    cond do
+      String.contains?(url, "1+%2B+1") -> {:ok, {[], [], @wolfram_xml}}
+      true -> {:ok, {[], [], "<queryresult></queryresult>"}}
+    end
+  end
+end

--- a/apps/info_sys/test/backends/wolfram_test.exs
+++ b/apps/info_sys/test/backends/wolfram_test.exs
@@ -1,0 +1,12 @@
+defmodule InfoSys.Backends.WolframTest do
+  use ExUnit.Case, async: true
+
+  test "makes request, reports results, then terminates" do
+    actual = hd InfoSys.compute("1 + 1", [])
+    assert actual.text == "2"
+  end
+
+  test "no query results reports an empty list" do
+    assert InfoSys.compute("none", [])
+  end
+end

--- a/apps/info_sys/test/fixtures/wolfram.xml
+++ b/apps/info_sys/test/fixtures/wolfram.xml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<queryresult success='true'
+             error='false'
+             numpods='6'
+             datatypes='Math'
+             timedout=''
+             timedoutpods=''
+             timing='1.0110000000000001'
+             parsetiming='0.11800000000000001'
+             parsetimedout='false'
+             recalculate=''
+             id='MSP67524764ic3g6h6ff0500004d0g0hga9fgaehbg'
+             host='https://www4b.wolframalpha.com'
+             server='9'
+             related='https://www4b.wolframalpha.com/api/v1/relatedQueries.jsp?id=MSPa67624764ic3g6h6ff0500001hh7hf4bh42ii2ie3938874040190114288'
+             version='2.6'>
+  <pod title='Input'
+       scanner='Identity'
+       id='Input'
+       position='100'
+       error='false'
+       numsubpods='1'>
+    <subpod title=''>
+      <img src='https://www4b.wolframalpha.com/Calculate/MSP/MSP67724764ic3g6h6ff0500005g22fd985ddhf06b?MSPStoreType=image/gif&amp;s=9'
+           alt='1 + 1'
+           title='1 + 1'
+           width='30'
+           height='18'
+           type='Default'
+           themes='1,2,3,4,5,6,7,8,9,10,11,12'
+           colorinvertable='true'/>
+      <plaintext>1 + 1</plaintext>
+    </subpod>
+    <expressiontypes count='1'>
+      <expressiontype name='Default'/>
+    </expressiontypes>
+  </pod>
+  <pod title='Result'
+       scanner='Simplification'
+       id='Result'
+       position='200'
+       error='false'
+       numsubpods='1'
+       primary='true'>
+    <subpod title=''>
+      <img src='https://www4b.wolframalpha.com/Calculate/MSP/MSP67824764ic3g6h6ff0500000i5e33eg966h8461?MSPStoreType=image/gif&amp;s=9'
+           alt='2'
+           title='2'
+           width='8'
+           height='18'
+           type='Default'
+           themes='1,2,3,4,5,6,7,8,9,10,11,12'
+           colorinvertable='true'/>
+      <plaintext>2</plaintext>
+    </subpod>
+    <expressiontypes count='1'>
+      <expressiontype name='Default'/>
+    </expressiontypes>
+    <states count='1'>
+      <state name='Step-by-step solution'
+             input='Result__Step-by-step solution'
+             stepbystep='true'/>
+    </states>
+  </pod>
+  <pod title='Number line'
+       scanner='NumberLine'
+       id='NumberLine'
+       position='300'
+       error='false'
+       numsubpods='1'>
+    <subpod title=''>
+      <img src='https://www4b.wolframalpha.com/Calculate/MSP/MSP67924764ic3g6h6ff0500002i33b1f3971h4gf9?MSPStoreType=image/gif&amp;s=9'
+           alt=''
+           title=''
+           width='330'
+           height='54'
+           type='1DMathPlot_2'
+           themes='1,2,3,4,5,6,7,8,9,10,11,12'
+           colorinvertable='true'/>
+      <plaintext></plaintext>
+    </subpod>
+    <expressiontypes count='1'>
+      <expressiontype name='1DMathPlot'/>
+    </expressiontypes>
+  </pod>
+  <pod title='Number name'
+       scanner='Integer'
+       id='NumberName'
+       position='400'
+       error='false'
+       numsubpods='1'>
+    <subpod title=''>
+      <img src='https://www4b.wolframalpha.com/Calculate/MSP/MSP68024764ic3g6h6ff0500003i9h4fd5hg0e7fia?MSPStoreType=image/gif&amp;s=9'
+           alt='two'
+           title='two'
+           width='25'
+           height='18'
+           type='Default'
+           themes='1,2,3,4,5,6,7,8,9,10,11,12'
+           colorinvertable='true'/>
+      <plaintext>two</plaintext>
+    </subpod>
+    <expressiontypes count='1'>
+      <expressiontype name='Default'/>
+    </expressiontypes>
+  </pod>
+  <pod title='Manipulatives illustration'
+       scanner='Arithmetic'
+       id='Illustration'
+       position='500'
+       error='false'
+       numsubpods='1'>
+    <subpod title=''>
+      <img src='https://www4b.wolframalpha.com/Calculate/MSP/MSP68124764ic3g6h6ff05000024f43d6h7a8g6i0e?MSPStoreType=image/gif&amp;s=9'
+           alt=' | + | | = |
+1 | | 1 | | 2'
+           title=' | + | | = |
+1 | | 1 | | 2'
+           width='112'
+           height='40'
+           type='Default'
+           themes='1,2,3,4,5,6,7,8,9,10,11,12'
+           colorinvertable='true'/>
+      <plaintext>| + | | = |
+        1 | | 1 | | 2
+      </plaintext>
+    </subpod>
+    <expressiontypes count='1'>
+      <expressiontype name='Default'/>
+    </expressiontypes>
+  </pod>
+  <pod title='Typical human computation times'
+       scanner='Arithmetic'
+       id='TypicalHumanComputationTimes'
+       position='600'
+       error='false'
+       numsubpods='1'>
+    <subpod title=''>
+      <microsources>
+        <microsource>HumanComputationQuery</microsource>
+      </microsources>
+      <img src='https://www4b.wolframalpha.com/Calculate/MSP/MSP68224764ic3g6h6ff0500000e8d8icb96e0h5i2?MSPStoreType=image/gif&amp;s=9'
+           alt='age 6: 3.2 seconds | age 8: 1.8 seconds | age 10: 1.2 seconds |
+age 18: 0.83 seconds
+(ignoring concentration, repetition, variations in education, etc.)'
+           title='age 6: 3.2 seconds | age 8: 1.8 seconds | age 10: 1.2 seconds |
+age 18: 0.83 seconds
+(ignoring concentration, repetition, variations in education, etc.)'
+           width='449'
+           height='64'
+           type='Grid'
+           themes='1,2,3,4,5,6,7,8,9,10,11,12'
+           colorinvertable='true'/>
+      <plaintext>age 6: 3.2 seconds | age 8: 1.8 seconds | age 10: 1.2 seconds |
+        age 18: 0.83 seconds
+        (ignoring concentration, repetition, variations in education, etc.)
+      </plaintext>
+    </subpod>
+    <expressiontypes count='1'>
+      <expressiontype name='Grid'/>
+    </expressiontypes>
+    <states count='1'>
+      <state name='More details'
+             input='TypicalHumanComputationTimes__More details'/>
+    </states>
+  </pod>
+  <sources count='1'>
+    <source url='https://www4b.wolframalpha.com/sources/HumanComputationQuerySourceInformationNotes.html'
+            text='Human computation query'/>
+  </sources>
+</queryresult>

--- a/apps/info_sys/test/test_helper.exs
+++ b/apps/info_sys/test/test_helper.exs
@@ -1,1 +1,2 @@
+Code.require_file "../../info_sys/test/backends/http_client.exs", __DIR__
 ExUnit.start()

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,3 +20,8 @@ config :logger, level: :warn
 # Reduce the rounds of hashing carried out in tests by Comeonin so password
 # hashing is faster in tests
 config :pbkdf2_elixir, :rounds, 1
+
+# Configure the http client and wolfram credentials for information system tests
+config :info_sys, :wolfram,
+  app_id: "1234",
+  http_client: InfoSys.Test.HTTPClient


### PR DESCRIPTION
Create a stub for a WolframAlpha request, referencing an actual API
result taken from a real request. Ensure the config requires the
fixture before running tests, and add configuration at the root level
for wolfram in the information system. Update the wolfram backend
to either user the Application http_client for wolfram or use the
Erlang :httpc, preventing a need to mock a full HTTP service. Finally
test results from the wolfram backend queries